### PR TITLE
Remove extra parameter

### DIFF
--- a/content/guide-device-creation.md
+++ b/content/guide-device-creation.md
@@ -53,7 +53,7 @@ use vulkano::device::DeviceExtensions;
 use vulkano::instance::Features;
 
 let (device, mut queues) = {
-    Device::new(physical, &Features::none(), &DeviceExtensions::none(), None,
+    Device::new(physical, &Features::none(), &DeviceExtensions::none(),
                 [(queue_family, 0.5)].iter().cloned()).expect("failed to create device")
 };
 ```


### PR DESCRIPTION
Device::new only accepts 4 arguments, an extra 5th 'None' argument seems be be a leftover.